### PR TITLE
Set python_min to 3.8 and remove runtime dep on opencv

### DIFF
--- a/.azure-pipelines/azure-pipelines-linux.yml
+++ b/.azure-pipelines/azure-pipelines-linux.yml
@@ -11,7 +11,7 @@ jobs:
       linux_64_:
         CONFIG: linux_64_
         UPLOAD_PACKAGES: 'True'
-        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-cos7-x86_64
+        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma9
   timeoutInMinutes: 360
   variables: {}
 

--- a/.ci_support/linux_64_.yaml
+++ b/.ci_support/linux_64_.yaml
@@ -5,4 +5,12 @@ channel_sources:
 channel_targets:
 - conda-forge main
 docker_image:
-- quay.io/condaforge/linux-anvil-cos7-x86_64
+- quay.io/condaforge/linux-anvil-x86_64:alma9
+pin_run_as_build:
+  python:
+    min_pin: x.x
+    max_pin: x.x
+python:
+- 3.12.* *_cpython
+python_min:
+- '3.9'

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "sahi" %}
 {% set version = "0.11.19" %}
-{% set python_min = "3.7" %}
+{% set python_min = "3.8" %}
 
 package:
   name: {{ name|lower }}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "sahi" %}
 {% set version = "0.11.19" %}
-{% set python_min = "3.6" %}
+{% set python_min = "3.7" %}
 
 package:
   name: {{ name|lower }}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,7 +11,7 @@ source:
   sha256: c80447778eaad711f5365c3d0313428b2ba133359f122a82f7bfd8836e594428
 
 build:
-  number: 0
+  number: 1
   noarch: python
   entry_points:
     - sahi=sahi.cli:app

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -32,7 +32,7 @@ requirements:
     - pytorch
     - pyyaml
     - requests
-    - shapely >=1.8.0
+    - shapely >=2.0.0
     - terminaltables
     - tqdm >=4.48.2
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -23,8 +23,6 @@ requirements:
     - python >=3.6
     - setuptools
   run:
-    - numpy <2.0.0
-    - opencv <=4.9.0.80
     - click
     - fire
     - pillow >=8.2.0

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "sahi" %}
 {% set version = "0.11.19" %}
-
+{% set python_min = "3.6" %}
 
 package:
   name: {{ name|lower }}
@@ -20,7 +20,7 @@ build:
 requirements:
   host:
     - pip
-    - python >=3.6
+    - python {{ python_min }}
     - setuptools
   run:
     - click
@@ -28,7 +28,7 @@ requirements:
     - pillow >=8.2.0
     - pybboxes ==0.1.6
     - py-opencv <=4.9.0.80
-    - python >=3.6
+    - python >={{ python_min }}
     - pytorch
     - pyyaml
     - requests
@@ -45,6 +45,7 @@ test:
     - sahi --help
   requires:
     - pip
+    - python {{ python_min }}
 
 about:
   home: https://github.com/obss/sahi

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -7,7 +7,7 @@ package:
   version: {{ version }}
 
 source:
-  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/sahi-{{ version }}.tar.gz
+  url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/sahi-{{ version }}.tar.gz
   sha256: c80447778eaad711f5365c3d0313428b2ba133359f122a82f7bfd8836e594428
 
 build:


### PR DESCRIPTION
Patches https://github.com/conda-forge/sahi-feedstock/pull/59 with the following changes:
- Set `python_min` and change to `pypi.org` url to satisfy linter - https://github.com/conda-forge/sahi-feedstock/pull/59#issuecomment-2493597296
- Remove opencv and numpy<2 pin following https://github.com/conda-forge/sahi-feedstock/pull/58#discussion_r1674766023

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
